### PR TITLE
Added clippy linting CI job

### DIFF
--- a/.github/workflows/reusable_tests.yaml
+++ b/.github/workflows/reusable_tests.yaml
@@ -85,7 +85,7 @@ jobs:
       - uses: ./.github/actions/parse-program-compute/
 
   clippy-format:
-    name: Test SkillValidator contracts
+    name: Uses cargo clippy for linting help
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:

--- a/.github/workflows/reusable_tests.yaml
+++ b/.github/workflows/reusable_tests.yaml
@@ -83,3 +83,13 @@ jobs:
       - run: anchor deploy
       - run: anchor test --arch sbf --skip-local-validator --skip-deploy --skip-build --run tests/SkillValidator
       - uses: ./.github/actions/parse-program-compute/
+
+  clippy-format:
+    name: Test SkillValidator contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup/
+      - run: cargo clippy
+


### PR DESCRIPTION
Added CI clippy linting job. Do note though that it is not configured to fail on clippy warnings due to several clippy warnings that we do not plan to remove rn or need to do more research on.  This is merely an observability CI tooling.